### PR TITLE
プルリク#47の修正案

### DIFF
--- a/documents/LaTeX_environment.tex
+++ b/documents/LaTeX_environment.tex
@@ -1295,8 +1295,9 @@ cloudlatexとは、株式会社アカリクが運営している\LaTeX のビル
 \section{Ultra Math Preview\index{Ultra Math Preview}}
 \subsection{Ultra Math Previewとは何か}
 Ultra Math Previewは、LaTeX Workshopよりも強力な数式プレビューができる拡張機能である。
-パッケージで定義されたコマンドもPreview することができる。
-さらにユーザー定義のmathPreview を導入することができるためにLaTeX Workshop 標準のプレビューよりもより利便性が高いものになっている。このmathPreview はMarkdownでも用いることができる。
+パッケージで定義されたコマンドもプレビューすることができる。
+さらにスタイルをカスタマイズすることができるため、LaTeX Workshop 標準のプレビューよりもより利便性が高いものになっている。
+このプレビューはMarkdownでも用いることができる。
 \begin{itemize}
   \item 数式を打つとプレビューが即座に出てくる
   \item LaTeX と Markdown で同じマクロがプレビューに使える
@@ -1323,12 +1324,12 @@ setting.jsonの\verb|{}|の中に次を入れることでlatexworkshopが対応�
 \subsection{Ultra Math Previewの設定の解説}
 設定の意味について記述する。
 \begin{description}
-  \item[umath.preview.toggleMathPreview] ホバーを出すか出さないかを制御することができる。
+  \item[umath.preview.toggleMathPreview] プレビューを出すか出さないかを制御することができる。
   \item[umath.preview.renderer] レンダリング（変換）に MathJax を使うか KaTeX を使うかを選択することができる。
   \item[umath.preview.macros] LaTeX のマクロを定義してレンダリングすることができる。
-  \item[umath.preview.position] ホバーを出す位置を変えることができる。
-  \item[umath.preview.customCSS]  ホバーの見た目を変えるCSS
-  \item[umath.preview.closeAllPreview]  表示されたホバーを非表示にすることができる。デフォルトではEScapeキーを押すことで非表示にすることができる。 
+  \item[umath.preview.position] プレビューを出す位置を変えることができる。
+  \item[umath.preview.customCSS]  プレビューの見た目を変えるCSS
+  \item[umath.preview.closeAllPreview]  表示されたプレビューを非表示にすることができる。デフォルトではEscapeキーを押すことで非表示にすることができる。 
 \end{description}
  
 \subsubsection{umath.preview.macros}


### PR DESCRIPTION
プルリクエストのレビューおよび修正案です
## 修正点
- ホバーの誤用
l1327
一般にUIの文脈で「ホバー」といえば「マウスホバー」の略で、カーソルを画面要素に重ねる動作のことを指します。

## 修正案
- ホバーの誤用
数式プレビューのようなマウスホバー時に表示される補足説明は「ツールチップ」と呼ばれるようですが、あまり一般的な用語ではないので今回は「プレビュー」で統一することにしました。

## 対応の方法
- 変更案をそのまま受け入れる場合
  プルリクをマージしてください

- さらに変更を加え変更案を受け入れる場合
  46-review-PR47ブランチで作業を行った後、マージしてください

- 変更案の受け入れを保留にしたい場合
  意図した内容と異なる、相談したい内容がある等、変更を保留にしたい場合はコメントでその理由を教えてください。
  コメントに応じて対応します

このレビューが解決された後、プルリク#47 をマージします。